### PR TITLE
Update userparameter_tcpstats.conf

### DIFF
--- a/zabbix_agentd.d/userparameter_tcpstats.conf
+++ b/zabbix_agentd.d/userparameter_tcpstats.conf
@@ -1,2 +1,2 @@
 # tcp stats
-UserParameter=tcp.zabbix.sender, /usr/local/bin/tcpstats.sh
+UserParameter=tcp.zabbix.sender,/usr/local/bin/tcpstats.sh


### PR DESCRIPTION
Removed pace between "...sender," and "/usr...".
Otherwise the ItemKey tcp.zabbix.sender falls in unsupported state in Zabbix